### PR TITLE
fix(compose): terminate on SIGTERM as well

### DIFF
--- a/src/app/exit/registerSignalListeners.ts
+++ b/src/app/exit/registerSignalListeners.ts
@@ -1,0 +1,15 @@
+import { TerminationCallback } from './buildTerminationCallback'
+
+/**
+ * Hooks into Node's process.on() listener to activate termination callback
+ */
+export type SignalListenerRegistrator = (terminationCallback: TerminationCallback) => void;
+
+export const base =
+  (nodeProcess: NodeJS.Process): SignalListenerRegistrator =>
+  (terminationCallback) => {
+    nodeProcess.on('SIGINT', terminationCallback);
+    nodeProcess.on('SIGTERM', terminationCallback);
+  };
+
+export default base(process)

--- a/src/app/exit/setupTerminationHandler.ts
+++ b/src/app/exit/setupTerminationHandler.ts
@@ -1,6 +1,7 @@
 import logger from '@/logger';
 import { MonitorStopper } from '@/monitors/MonitorStopper'
 import buildTerminationCallback, { TerminationCallbackBuilder } from './buildTerminationCallback'
+import registerSignalListeners, { SignalListenerRegistrator } from './registerSignalListeners'
 
 export type TerminationHandler = () => void;
 
@@ -11,10 +12,10 @@ export type TerminationHandler = () => void;
 export type TerminationHandlerSetup = (stoppers: MonitorStopper[]) => TerminationHandler;
 
 export const base = 
-  (nodeProcess: NodeJS.Process, buildTerminationCallback: TerminationCallbackBuilder): TerminationHandlerSetup =>
+  (buildTerminationCallback: TerminationCallbackBuilder, registerSignalListeners: SignalListenerRegistrator): TerminationHandlerSetup =>
   (stoppers) => {
     const terminationCallback = buildTerminationCallback(stoppers);
-    nodeProcess.on('SIGINT', terminationCallback);
+    registerSignalListeners(terminationCallback);
 
     logger.debug('Set up process termination handler');
 
@@ -22,4 +23,4 @@ export const base =
   }
 
 /** Stops all monitors on process exit event */
-export default base(process, buildTerminationCallback);
+export default base(buildTerminationCallback, registerSignalListeners);

--- a/tests/unit/app/exit/registerSignalListeners.spec.ts
+++ b/tests/unit/app/exit/registerSignalListeners.spec.ts
@@ -1,0 +1,24 @@
+import sinon, { SinonSpy } from 'sinon'
+import { TerminationCallback } from '../../../../src/app/exit/buildTerminationCallback'
+import { base } from '../../../../src/app/exit/registerSignalListeners'
+
+describe('app/exit/registerSignalListeners', () => {
+
+  const terminationCallback = Symbol() as unknown as TerminationCallback;
+  let nodeProcess: NodeJS.Process;
+
+  beforeEach(() => {
+    nodeProcess = { on: sinon.fake.returns(nodeProcess) } as unknown as NodeJS.Process;
+  })
+  
+  beforeEach(() => base(nodeProcess)(terminationCallback))
+
+  it('Registers callback for SIGINT', () => {
+    sinon.assert.calledWithExactly(nodeProcess.on as SinonSpy, 'SIGINT', terminationCallback);
+  })
+
+  it('Registers callback for SIGTERM', () => {
+    sinon.assert.calledWithExactly(nodeProcess.on as SinonSpy, 'SIGTERM', terminationCallback);
+  })
+
+})


### PR DESCRIPTION
Executes callback on SIGTERM in addition to SIGINT (previously).
Fixes #25